### PR TITLE
Enable to install by Packagist

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,6 @@ ray/oauth-module
 
 ### Composer install
 
-```composer.json
-{
-	"repositories": [
-		{
-			"type": "vcs",
-			"url": "https://github.com/kawanamiyuu/Ray.OAuthModule"
-		}
-	]
-}
-```
-
 ```bash
 $ composer require ray/oauth-module
 ```


### PR DESCRIPTION
Packagistからのinstall

+ [x] Packagistへの登録

  →https://packagist.org/packages/ray/oauth-module

+ [x] GitHub Service Hook の設定