### PR TITLE
enable to select Token Storage implementaions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ language: php
 php:
   - 5.5
   - 5.6
+  - 7
   - hhvm
 
-script:
- - composer install --prefer-source
- - phpunit --coverage-text --coverage-clover=coverage.clover
+before_script:
+  - composer self-update
+  - composer install
 
-after_script:
- - wget https://scrutinizer-ci.com/ocular.phar
- - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+script:
+  - composer test

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
 	"license": "MIT",
 	"require": {
 		"php": ">=5.5.0",
-		"ray/di": "~2.0",
-		"maye/oauth-client": "~1.1"
+		"ray/di": "~2.3",
+		"maye/oauth-client": "~1.3"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "3.7.*"

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,10 @@
 		"maye/oauth-client": "~1.3"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "3.7.*"
+		"phpunit/phpunit": "~4.8",
+		"squizlabs/php_codesniffer": "~2.6",
+		"phpmd/phpmd": "~2.4",
+		"fabpot/php-cs-fixer": "~1.11"
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,
@@ -23,5 +26,16 @@
 			"Ray\\OAuthModule\\": "tests/",
 			"Ray\\OAuthModule\\": "tests/Fake"
 		}
+	},
+	"scripts": {
+		"test": [
+			"phpmd src text ./phpmd.xml",
+			"phpcs src tests",
+			"phpunit --coverage-text"
+		],
+		"cs-fix": [
+			"php-cs-fixer fix --config-file=./.php_cs --diff -v",
+			"phpcbf src"
+		]
 	}
 }

--- a/docs/demo/run.php
+++ b/docs/demo/run.php
@@ -18,7 +18,7 @@ class Fake
     }
 }
 
-/**
+/*
  * (Emulates $_SERVER and $_ENV variables for CLI)
  */
 $_SERVER['REQUEST_URI'] = 'http://127.0.0.1:8080/';

--- a/docs/demo/run_by_app_module.php
+++ b/docs/demo/run_by_app_module.php
@@ -28,7 +28,7 @@ class AppModule extends AbstractModule
     }
 }
 
-/**
+/*
  * (Emulates $_SERVER and $_ENV variables for CLI)
  */
 $_SERVER['REQUEST_URI'] = 'http://127.0.0.1:8080/auth/';

--- a/docs/demo/www/oauth1_twitter.php
+++ b/docs/demo/www/oauth1_twitter.php
@@ -74,7 +74,7 @@ class OAuthController
 
         // requests AccessToken
         $token = $this->twitterOAuth->requestAccessToken($oauth_token, $oauth_verifier);
-        /** @var OAuth\OAuth1\Token\TokenInterface $token */
+        /* @var OAuth\OAuth1\Token\TokenInterface $token */
 
         // $accessToken       = $token->getAccessToken();
         // $accessTokenSecret = $token->getAccessTokenSecret();

--- a/docs/demo/www/oauth2_facebook.php
+++ b/docs/demo/www/oauth2_facebook.php
@@ -73,7 +73,7 @@ class OAuthController
 
         // requests AccessToken
         $token = $this->facebookOAuth->requestAccessToken($code);
-        /** @var OAuth\OAuth2\Token\TokenInterface $token */
+        /* @var OAuth\OAuth2\Token\TokenInterface $token */
 
         // $accessToken = $token->getAccessToken();
         // $refreshToken = $token->getRefreshToken();

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<ruleset>
+    <description>The coding standard used for applications using BEAR.Sunday Framework.</description>
+    <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
+    <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
+    <rule ref="Generic.Strings.UnnecessaryStringConcat"/>
+    <rule ref="PSR2">
+        <exclude name="Generic.Files.LineLength"/>
+        <exclude name="PSR2.Classes.PropertyDeclaration.Underscore"/>
+        <exclude name="PSR2.Methods.MethodDeclaration.Underscore"/>
+    </rule>
+    <!--<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>-->
+    <rule ref="PEAR.Commenting.FunctionComment">
+        <exclude name="PEAR.Commenting.FunctionComment.MissingReturn"/>
+        <exclude name="PEAR.Commenting.FunctionComment.MissingParamComment"/>
+        <exclude name="PEAR.Commenting.FunctionComment.SpacingBeforeTags"/>
+        <exclude name="PEAR.Commenting.FunctionComment.MissingParamTag"/>
+        <exclude name="PEAR.Commenting.FunctionComment.Missing"/>
+        <exclude name="PEAR.Commenting.FunctionComment.MissingReturn"/>
+        <exclude name="PEAR.Commenting.FunctionComment.ParameterCommentsNotAligned"/>
+        <exclude name="PEAR.Commenting.FileComment.Missing"/>
+    </rule>
+    <file>src</file>
+    <file>tests</file>
+</ruleset>

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -1,0 +1,50 @@
+<ruleset
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://pmd.sf.net/ruleset/1.0.0"
+        xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
+        xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+    <!--codesize-->
+    <rule ref="rulesets/codesize.xml/CyclomaticComplexity">
+        <properties>
+            <property name="reportLevel" value="20"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/codesize.xml/NPathComplexity">
+        <properties>
+            <property name="minimum" value="200"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/codesize.xml/ExcessiveClassComplexity">
+        <properties>
+            <property name="maximum" value="100"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/codesize.xml/ExcessiveClassLength"/>
+    <rule ref="rulesets/codesize.xml/ExcessiveMethodLength"/>
+    <rule ref="rulesets/codesize.xml/ExcessiveParameterList"/>
+    <rule ref="rulesets/codesize.xml/ExcessivePublicCount"/>
+    <rule ref="rulesets/codesize.xml/TooManyFields"/>
+    <rule ref="rulesets/codesize.xml/TooManyMethods"/>
+    <!--design-->
+    <rule ref="rulesets/design.xml/EvalExpression"/>
+    <rule ref="rulesets/design.xml/ExitExpression"/>
+    <rule ref="rulesets/design.xml/GotoStatement" />
+    <rule ref="rulesets/design.xml/NumberOfChildren"/>
+    <rule ref="rulesets/design.xml/DepthOfInheritance"/>
+    <!-- <rule ref="rulesets/design.xml/CouplingBetweenObjects" /> -->
+    <!--naming-->
+    <rule ref="rulesets/naming.xml/ConstantNamingConventions"/>
+    <rule ref="rulesets/naming.xml/BooleanGetMethodName"/>
+    <!--unusedcode-->
+    <rule ref="rulesets/unusedcode.xml/UnusedFormalParameter"/>
+    <rule ref="rulesets/unusedcode.xml/UnusedLocalVariable"/>
+    <rule ref="rulesets/unusedcode.xml/UnusedPrivateField"/>
+    <rule ref="rulesets/unusedcode.xml/UnusedPrivateMethod"/>
+    <!--controversial-->
+    <rule ref="rulesets/controversial.xml/CamelCaseClassName"/>
+    <rule ref="rulesets/controversial.xml/CamelCasePropertyName"/>
+    <rule ref="rulesets/controversial.xml/CamelCaseMethodName"/>
+    <!--cleancode-->
+    <rule ref="rulesets/cleancode.xml/BooleanArgumentFlag"/>
+    <!-- <rule ref="rulesets/cleancode.xml/ElseExpression" /> -->
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,6 +20,8 @@
         <whitelist>
             <directory suffix=".php">src</directory>
             <exclude>
+                <directory>src/Annotation</directory>
+                <directory>src/Inject</directory>
                 <file>src/DoctrineAnnotations.php</file>
             </exclude>
         </whitelist>

--- a/src/OAuth1Module.php
+++ b/src/OAuth1Module.php
@@ -8,6 +8,7 @@ namespace Ray\OAuthModule;
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Maye\OAuthClient\OAuth1ClientInterface;
+use OAuth\Common\Storage\TokenStorageInterface;
 use Ray\Di\AbstractModule;
 use Ray\Di\Scope;
 use Ray\OAuthModule\Annotation\OAuth1Config;
@@ -25,13 +26,15 @@ class OAuth1Module extends AbstractModule
      * @param string $consumerSecret  Consumer secret
      * @param string $callbackUrlPath Callback url path
      * @param array  $extraAuthParams Extra authorization params
+     * @param TokenStorageInterface $storage Token Storage
      */
-    public function __construct($serviceName, $consumerKey, $consumerSecret, $callbackUrlPath, array $extraAuthParams = [])
+    public function __construct($serviceName, $consumerKey, $consumerSecret, $callbackUrlPath,
+                                array $extraAuthParams = [], TokenStorageInterface $storage = null)
     {
         $this->serviceName = $serviceName;
 
         AnnotationRegistry::registerFile(__DIR__ . '/DoctrineAnnotations.php');
-        $this->bind()->annotatedWith(OAuth1Config::class)->toInstance([$serviceName, $consumerKey, $consumerSecret, $callbackUrlPath, $extraAuthParams]);
+        $this->bind()->annotatedWith(OAuth1Config::class)->toInstance([$serviceName, $consumerKey, $consumerSecret, $callbackUrlPath, $extraAuthParams, $storage]);
     }
 
     /**

--- a/src/OAuth1Module.php
+++ b/src/OAuth1Module.php
@@ -21,16 +21,21 @@ class OAuth1Module extends AbstractModule
     private $serviceName;
 
     /**
-     * @param string $serviceName     Service name
-     * @param string $consumerKey     Consumer key
-     * @param string $consumerSecret  Consumer secret
-     * @param string $callbackUrlPath Callback url path
-     * @param array  $extraAuthParams Extra authorization params
-     * @param TokenStorageInterface $storage Token Storage
+     * @param string                $serviceName     Service name
+     * @param string                $consumerKey     Consumer key
+     * @param string                $consumerSecret  Consumer secret
+     * @param string                $callbackUrlPath Callback url path
+     * @param array                 $extraAuthParams Extra authorization params
+     * @param TokenStorageInterface $storage         Token Storage
      */
-    public function __construct($serviceName, $consumerKey, $consumerSecret, $callbackUrlPath,
-                                array $extraAuthParams = [], TokenStorageInterface $storage = null)
-    {
+    public function __construct(
+        $serviceName,
+        $consumerKey,
+        $consumerSecret,
+        $callbackUrlPath,
+        array $extraAuthParams = [],
+        TokenStorageInterface $storage = null
+    ) {
         $this->serviceName = $serviceName;
 
         AnnotationRegistry::registerFile(__DIR__ . '/DoctrineAnnotations.php');

--- a/src/OAuth1Provider.php
+++ b/src/OAuth1Provider.php
@@ -35,8 +35,8 @@ class OAuth1Provider implements ProviderInterface
      */
     public function get()
     {
-        list($serviceName, $consumerKey, $consumerSecret, $callbackUrlPath, $extraAuthParams) = $this->config;
+        list($serviceName, $consumerKey, $consumerSecret, $callbackUrlPath, $extraAuthParams, $storage) = $this->config;
 
-        return new OAuth1Client($serviceName, $consumerKey, $consumerSecret, $callbackUrlPath, $extraAuthParams);
+        return new OAuth1Client($serviceName, $consumerKey, $consumerSecret, $callbackUrlPath, $extraAuthParams, $storage);
     }
 }

--- a/src/OAuth1Service.php
+++ b/src/OAuth1Service.php
@@ -14,6 +14,5 @@ class OAuth1Service
      * the following services are available:
      * https://github.com/Lusitanian/PHPoAuthLib/tree/master/src/OAuth/OAuth1/Service
      */
-
     const TWITTER = 'Twitter';
 }

--- a/src/OAuth2Module.php
+++ b/src/OAuth2Module.php
@@ -8,6 +8,7 @@ namespace Ray\OAuthModule;
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Maye\OAuthClient\OAuth2ClientInterface;
+use OAuth\Common\Storage\TokenStorageInterface;
 use Ray\Di\AbstractModule;
 use Ray\Di\Scope;
 use Ray\OAuthModule\Annotation\OAuth2Config;
@@ -26,13 +27,15 @@ class OAuth2Module extends AbstractModule
      * @param string $callbackUrlPath Callback url path
      * @param array  $scopes          Scopes
      * @param array  $extraAuthParams Extra authorization params
+     * @param TokenStorageInterface $storage Token Storage
      */
-    public function __construct($serviceName, $consumerKey, $consumerSecret, $callbackUrlPath, array $scopes = [], array $extraAuthParams = [])
+    public function __construct($serviceName, $consumerKey, $consumerSecret, $callbackUrlPath,
+                                array $scopes = [], array $extraAuthParams = [], TokenStorageInterface $storage = null)
     {
         $this->serviceName = $serviceName;
 
         AnnotationRegistry::registerFile(__DIR__ . '/DoctrineAnnotations.php');
-        $this->bind()->annotatedWith(OAuth2Config::class)->toInstance([$serviceName, $consumerKey, $consumerSecret, $callbackUrlPath, $scopes, $extraAuthParams]);
+        $this->bind()->annotatedWith(OAuth2Config::class)->toInstance([$serviceName, $consumerKey, $consumerSecret, $callbackUrlPath, $scopes, $extraAuthParams, $storage]);
     }
 
     /**

--- a/src/OAuth2Module.php
+++ b/src/OAuth2Module.php
@@ -21,17 +21,23 @@ class OAuth2Module extends AbstractModule
     private $serviceName;
 
     /**
-     * @param string $serviceName     Service name
-     * @param string $consumerKey     Consumer key
-     * @param string $consumerSecret  Consumer secret
-     * @param string $callbackUrlPath Callback url path
-     * @param array  $scopes          Scopes
-     * @param array  $extraAuthParams Extra authorization params
-     * @param TokenStorageInterface $storage Token Storage
+     * @param string                $serviceName     Service name
+     * @param string                $consumerKey     Consumer key
+     * @param string                $consumerSecret  Consumer secret
+     * @param string                $callbackUrlPath Callback url path
+     * @param array                 $scopes          Scopes
+     * @param array                 $extraAuthParams Extra authorization params
+     * @param TokenStorageInterface $storage         Token Storage
      */
-    public function __construct($serviceName, $consumerKey, $consumerSecret, $callbackUrlPath,
-                                array $scopes = [], array $extraAuthParams = [], TokenStorageInterface $storage = null)
-    {
+    public function __construct(
+        $serviceName,
+        $consumerKey,
+        $consumerSecret,
+        $callbackUrlPath,
+        array $scopes = [],
+        array $extraAuthParams = [],
+        TokenStorageInterface $storage = null
+    ) {
         $this->serviceName = $serviceName;
 
         AnnotationRegistry::registerFile(__DIR__ . '/DoctrineAnnotations.php');

--- a/src/OAuth2Provider.php
+++ b/src/OAuth2Provider.php
@@ -35,8 +35,8 @@ class OAuth2Provider implements ProviderInterface
      */
     public function get()
     {
-        list($serviceName, $consumerKey, $consumerSecret, $callbackUrlPath, $scopes, $extraAuthParams) = $this->config;
+        list($serviceName, $consumerKey, $consumerSecret, $callbackUrlPath, $scopes, $extraAuthParams, $storage) = $this->config;
 
-        return new OAuth2Client($serviceName, $consumerKey, $consumerSecret, $callbackUrlPath, $scopes, $extraAuthParams);
+        return new OAuth2Client($serviceName, $consumerKey, $consumerSecret, $callbackUrlPath, $scopes, $extraAuthParams, $storage);
     }
 }

--- a/src/OAuth2Service.php
+++ b/src/OAuth2Service.php
@@ -14,7 +14,6 @@ class OAuth2Service
      * the following services are available:
      * https://github.com/Lusitanian/PHPoAuthLib/tree/master/src/OAuth/OAuth2/Service
      */
-
     const FACEBOOK = 'Facebook';
 
     const GIT_HUB = 'GitHub';

--- a/tests/Fake/FakeTokenStorage.php
+++ b/tests/Fake/FakeTokenStorage.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Ray\OAuthModule;
+
+use OAuth\Common\Storage\TokenStorageInterface;
+use OAuth\Common\Token\TokenInterface;
+
+class FakeTokenStorage implements TokenStorageInterface
+{
+    public function retrieveAccessToken($service)
+    {
+    }
+
+    public function storeAccessToken($service, TokenInterface $token)
+    {
+    }
+
+    public function hasAccessToken($service)
+    {
+    }
+
+    public function clearToken($service)
+    {
+    }
+
+    public function clearAllTokens()
+    {
+    }
+
+    public function storeAuthorizationState($service, $state)
+    {
+    }
+
+    public function hasAuthorizationState($service)
+    {
+    }
+
+    public function retrieveAuthorizationState($service)
+    {
+    }
+
+    public function clearAuthorizationState($service)
+    {
+    }
+
+    public function clearAllAuthorizationStates()
+    {
+    }
+}

--- a/tests/OAuth1ModuleTest.php
+++ b/tests/OAuth1ModuleTest.php
@@ -14,8 +14,7 @@ class OAuth1ModuleTest extends \PHPUnit_Framework_TestCase
 {
     public function testOAuth1Module()
     {
-        $module = new OAuth1Module(
-            OAuth1Service::TWITTER, 'ConsumerKey', 'ConsumerSecret', 'CallbackUrlPath', [], new FakeTokenStorage);
+        $module = new OAuth1Module(OAuth1Service::TWITTER, 'ConsumerKey', 'ConsumerSecret', 'CallbackUrlPath', [], new FakeTokenStorage);
         $injector = (new Injector($module, $_ENV['TMP_DIR']));
         /** @var FakeOAuth1Consumer $consumer */
         $consumer = $injector->getInstance(FakeOAuth1Consumer::class);

--- a/tests/OAuth1ModuleTest.php
+++ b/tests/OAuth1ModuleTest.php
@@ -7,18 +7,37 @@
 namespace Ray\OAuthModule;
 
 use Maye\OAuthClient\OAuth1ClientInterface;
+use OAuth\Common\Storage\TokenStorageInterface;
 use Ray\Di\Injector;
 
 class OAuth1ModuleTest extends \PHPUnit_Framework_TestCase
 {
     public function testOAuth1Module()
     {
-        $module = new OAuth1Module(OAuth1Service::TWITTER, 'ConsumerKey', 'ConsumerSecret', 'CallbackUrlPath');
+        $module = new OAuth1Module(
+            OAuth1Service::TWITTER, 'ConsumerKey', 'ConsumerSecret', 'CallbackUrlPath', [], new FakeTokenStorage);
         $injector = (new Injector($module, $_ENV['TMP_DIR']));
         /** @var FakeOAuth1Consumer $consumer */
         $consumer = $injector->getInstance(FakeOAuth1Consumer::class);
 
         $this->assertInstanceOf(OAuth1ClientInterface::class, $consumer->getClient());
         $this->assertEquals(OAuth1Service::TWITTER, $consumer->getClient()->getServiceName());
+
+        $this->assertInstanceOf(FakeTokenStorage::class, $this->getStorage($consumer->getClient()));
+    }
+
+    /**
+     * @param OAuth1ClientInterface $client
+     *
+     * @return TokenStorageInterface
+     */
+    private function getStorage(OAuth1ClientInterface $client)
+    {
+        $clazz = new \ReflectionClass($client);
+        $prop = $clazz->getProperty('service');
+        $prop->setAccessible(true);
+        $service = $prop->getValue($client);
+
+        return $service->getStorage();
     }
 }

--- a/tests/OAuth2ModuleTest.php
+++ b/tests/OAuth2ModuleTest.php
@@ -7,6 +7,7 @@
 namespace Ray\OAuthModule;
 
 use Maye\OAuthClient\OAuth2ClientInterface;
+use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\OAuth2\Service\Facebook;
 use Ray\Di\Injector;
 
@@ -14,12 +15,30 @@ class OAuth2ModuleTest extends \PHPUnit_Framework_TestCase
 {
     public function testOAuth2Module()
     {
-        $module = new OAuth2Module(OAuth2Service::FACEBOOK, 'ConsumerKey', 'ConsumerSecret', 'CallbackUrlPath', [Facebook::SCOPE_READ_STREAM]);
+        $module = new OAuth2Module(
+            OAuth2Service::FACEBOOK, 'ConsumerKey', 'ConsumerSecret', 'CallbackUrlPath', [Facebook::SCOPE_READ_STREAM], [], new FakeTokenStorage);
         $injector = (new Injector($module, $_ENV['TMP_DIR']));
         /** @var FakeOAuth2Consumer $consumer */
         $consumer = $injector->getInstance(FakeOAuth2Consumer::class);
 
         $this->assertInstanceOf(OAuth2ClientInterface::class, $consumer->getClient());
         $this->assertEquals(OAuth2Service::FACEBOOK, $consumer->getClient()->getServiceName());
+        
+        $this->assertInstanceOf(FakeTokenStorage::class, $this->getStorage($consumer->getClient()));
+    }
+
+    /**
+     * @param OAuth2ClientInterface $client
+     *
+     * @return TokenStorageInterface
+     */
+    private function getStorage(OAuth2ClientInterface $client)
+    {
+        $clazz = new \ReflectionClass($client);
+        $prop = $clazz->getProperty('service');
+        $prop->setAccessible(true);
+        $service = $prop->getValue($client);
+
+        return $service->getStorage();
     }
 }

--- a/tests/OAuth2ModuleTest.php
+++ b/tests/OAuth2ModuleTest.php
@@ -15,15 +15,14 @@ class OAuth2ModuleTest extends \PHPUnit_Framework_TestCase
 {
     public function testOAuth2Module()
     {
-        $module = new OAuth2Module(
-            OAuth2Service::FACEBOOK, 'ConsumerKey', 'ConsumerSecret', 'CallbackUrlPath', [Facebook::SCOPE_READ_STREAM], [], new FakeTokenStorage);
+        $module = new OAuth2Module(OAuth2Service::FACEBOOK, 'ConsumerKey', 'ConsumerSecret', 'CallbackUrlPath', [Facebook::SCOPE_READ_STREAM], [], new FakeTokenStorage);
         $injector = (new Injector($module, $_ENV['TMP_DIR']));
         /** @var FakeOAuth2Consumer $consumer */
         $consumer = $injector->getInstance(FakeOAuth2Consumer::class);
 
         $this->assertInstanceOf(OAuth2ClientInterface::class, $consumer->getClient());
         $this->assertEquals(OAuth2Service::FACEBOOK, $consumer->getClient()->getServiceName());
-        
+
         $this->assertInstanceOf(FakeTokenStorage::class, $this->getStorage($consumer->getClient()));
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,7 +4,6 @@
  *
  * @license http://opensource.org/licenses/mit-license.php MIT
  */
-
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 $_ENV['TMP_DIR'] = __DIR__ . '/tmp';


### PR DESCRIPTION
```php
$module = new OAuth1Module(
    OAuth1Service::TWITTER, 
    'ConsumerKey', 
    'ConsumerSecret', 
    '/callback', 
    ['force_login' => 'true'], 
    new \OAuth\Common\Storage\Session(...) // use PHP built-in Session
);

$module = new OAuth1Module(
    OAuth1Service::TWITTER, 
    'ConsumerKey', 
    'ConsumerSecret', 
    '/callback', 
    ['force_login' => 'true'], 
    new \OAuth\Common\Storage\SymfonySession(...) // use Symfony Session
);  
```